### PR TITLE
Orders PATCH, Mock Data fix, orders GET now requires exact status match.

### DIFF
--- a/docs/orders/get.yml
+++ b/docs/orders/get.yml
@@ -49,7 +49,7 @@ parameters:
   - in: query
     name: status
     required: false
-    description: Filters results matching the `status` column. Supports partial matches.
+    description: Filters results matching the `status` column. (`accepted`, `rejected`, `pending`, `canceled`, `ready`)
     schema:
       type: string
   - in: query

--- a/docs/orders/patch.yml
+++ b/docs/orders/patch.yml
@@ -1,0 +1,42 @@
+Order records
+---
+tags:
+    - Orders
+description:
+    Updates order record. All fields are optional.
+responses:
+    200:
+        description: prescription successfully updated.
+    400:
+        description: Client input validation error.
+    404:
+        description: prescription ID not found.
+    500:
+        description: Server/SQLite error.
+consumes:
+  - application/json
+parameters:
+    - in: path
+      name: order_id
+      required: true
+      description: order ID to update
+      schema:
+        type: integer
+    - in: body
+      name: prescription
+      required: true
+      description: | 
+        Prescription information
+      schema:
+        type: object
+        properties: 
+          medication_id: 
+            type: integer
+            description: Medication ID
+          status: 
+            type: string
+            description: Must be (`accepted`, `rejected`, `pending`, `canceled`, `ready`)
+          patient_id: 
+            type: integer
+            description: Patient ID
+

--- a/pharma.py
+++ b/pharma.py
@@ -5,6 +5,7 @@ from flask_cors import CORS
 from flasgger import Swagger, swag_from
 import pika
 import requests
+import json
 
 HOST = 'localhost'
 app = Flask(__name__)
@@ -50,6 +51,15 @@ def listen_for_orders():
         channel.queue_declare(queue='orders')
         channel.basic_consume(queue='orders', on_message_callback=order_callback)
         channel.start_consuming()
+
+def send_order_update(params):
+    message = json.dumps(params)
+    connection = pika.BlockingConnection(pika.ConnectionParameters(HOST))
+    channel = connection.channel()
+    channel.queue_declare(queue='order_updates')
+    channel.basic_publish(exchange='', routing_key='order_updates', body=message)
+    print(f"Sent {message}")
+    connection.close()
 
 @app.route("/")
 def home():
@@ -115,8 +125,42 @@ def get_medications():
         })
     return json_response, 200
 
+@app.route('/orders/<int:order_id>', methods=['PATCH'])
+@swag_from('docs/orders/patch.yml')
+def update_order(order_id):
+    params = {
+        'order_id': order_id,
+        'medication_id': request.json.get('medication_id'),
+        'status': request.json.get('status'),
+        'patient_id': request.json.get('patient_id')
+    }
+    query = text(f"""
+        UPDATE orders SET
+            medication_id = {':medication_id' if params['medication_id'] != None else 'medication_id'},
+            status = {':status' if params['status'] != None else 'status'},
+            patient_id = {':patient_id' if params['patient_id'] != None else 'patient_id'}
+        WHERE order_id = :order_id
+    """)
+    #input validation
+    if(all(param == None for param in list(params.values())[1:])):
+        return ResponseMessage("Updated nothing.", 200)
+    if(not ValidTableID('orders', 'order_id', order_id)):
+        return ResponseMessage("Invalid Order ID.", 404)
+    if(params['medication_id'] != None and not ValidTableID('medications', 'medication_id', params['medication_id'])):
+        return ResponseMessage("Invalid Medication ID.", 400)
+    if(params['status'] != None and params['status'].lower() not in ('accepted', 'rejected', 'pending', 'canceled', 'ready')):
+        return ResponseMessage("Invalid status. (must be 'accepted', 'rejected', 'pending', 'canceled', or 'ready')", 400)
+    #database update
+    try:
+        db.session.execute(query, params)
+    except Exception as e:
+        print(e)
+        return ResponseMessage("Server error updating order.", 500)
+    else:
+        send_order_update(params)
+        return ResponseMessage("Order Updated.", 200)
 
-@app.route("/order_history", methods=['GET'])
+@app.route("/orders", methods=['GET'])
 @swag_from('docs/orders/get.yml')
 def get_orders():
     query = "SELECT O.*, M.name FROM orders AS O JOIN medications AS M ON M.medication_id = O.medication_id\n"
@@ -133,7 +177,7 @@ def get_orders():
     if params['medication_id'] != "":
         conditions.append("O.medication_id = :medication_id")
     if params['status'] != "":
-        conditions.append("O.status LIKE :status")
+        conditions.append("O.status = :status")
     if params['patient_id'] != "":
         conditions.append("O.patient_id = :patient_id")
     
@@ -152,6 +196,8 @@ def get_orders():
         })
     return json_response, 200
 
+def ValidTableID(table:str, id_field:str, id:int):
+    return db.session.execute(text(f"SELECT * FROM {table} WHERE {id_field} = :id"), {'id': id}) != None
         
 def ResponseMessage(message, code):
     return {'message': message}, code

--- a/pharma.py
+++ b/pharma.py
@@ -157,6 +157,7 @@ def update_order(order_id):
         print(e)
         return ResponseMessage("Server error updating order.", 500)
     else:
+        db.session.commit()
         send_order_update(params)
         return ResponseMessage("Order Updated.", 200)
 

--- a/pharma_data.sql
+++ b/pharma_data.sql
@@ -33,7 +33,7 @@ INSERT INTO "orders" VALUES (1, 1, 'pending', 101);
 INSERT INTO "orders" VALUES (2, 2, 'completed', 102);
 INSERT INTO "orders" VALUES (3, 3, 'pending', 103);
 INSERT INTO "orders" VALUES (4, 4, 'cancelled', 104);
-INSERT INTO "orders" VALUES (5, 5, 'shipped', 105);
+INSERT INTO "orders" VALUES (5, 5, 'pending', 105);
 INSERT INTO "orders" VALUES (6, 6, 'pending', 106);
 INSERT INTO "orders" VALUES (7, 7, 'completed', 107);
 INSERT INTO "orders" VALUES (8, 8, 'pending', 108);


### PR DESCRIPTION
Orders PATCH notifies the main backend of the change through RabbitMQ.
Mock data had an erroneous "shipped" status, which doesn't exist anywhere else.
Status really didnt need to support partial matches so now exact is required. SQL isn't case sensitive anyway.